### PR TITLE
New SPT3G v3 release

### DIFF
--- a/spt3g_2020/spt3g.py
+++ b/spt3g_2020/spt3g.py
@@ -34,7 +34,7 @@ default_spectra_list = [
 
 class SPT3GPrototype(InstallableLikelihood):
     install_options = {
-        "download_url": "https://pole.uchicago.edu/public/data/dutcher21/SPT3G_2018_EETE_likelihood.tar.gz",
+        "download_url": "https://pole.uchicago.edu/public/data/dutcher21/SPT3G_2018_EETE_likelihood_v3.zip",
         "data_path": "spt3g_2018",
     }
 
@@ -58,7 +58,7 @@ class SPT3GPrototype(InstallableLikelihood):
     # SPT-3G Y1 EE/TE Effective band centres for polarised galactic dust.
     nu_eff_list: Optional[dict] = {90: 9.670270e01, 150: 1.499942e02, 220: 2.220433e02}
 
-    data_folder: Optional[str] = "spt3g_2018/SPT3G_2018_EETE_likelihood/data/SPT3G_Y1_EETE"
+    data_folder: Optional[str] = "spt3g_2018/SPT3G_2018_EETE_likelihood_v3/data/SPT3G_Y1_EETE"
     bp_file: Optional[str]
     cov_file: Optional[str]
     beam_cov_file: Optional[str]

--- a/spt3g_2020/tests/test_spt3g.py
+++ b/spt3g_2020/tests/test_spt3g.py
@@ -57,7 +57,9 @@ class SPT3GTest(unittest.TestCase):
         test_dir = os.path.dirname(__file__)
         dl_te, dl_ee = np.load(os.path.join(test_dir, "data", "dlte_ee_from_cosmomc.npy"))
         loglike = my_spt.loglike(dl_te, dl_ee, **fg_params)
-        self.assertAlmostEqual(-2 * loglike, 1160.1925138672325, 5)
+        # self.assertAlmostEqual(-2 * loglike, 1160.1925138672325, 5)
+        # New number from SPT3G v3 release
+        self.assertAlmostEqual(-2 * loglike, 1142.9992859507431, 5)
 
     def test_cobaya(self):
         """Test the Cobaya interface to the SPT3G likelihood."""
@@ -73,7 +75,7 @@ class SPT3GTest(unittest.TestCase):
 
         model = get_model(info)
         chi2 = -2 * model.loglike({})[0]
-        self.assertAlmostEqual(chi2, 1160.1925138672325, 2)
+        self.assertAlmostEqual(chi2, 1143.0310254786946, 2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Using latest data release (October 28, 2021)

See https://pole.uchicago.edu/public/data/dutcher21/

> Errata
> (October 28, 2021): We update the final temperature and polarization calibration of the SPT-3G band powers and the beam covariance matrix. The new calibration has a negligible impact impact on cosmological parameter constraints, apart from the combined amplitude parameter, which shifts by 20% of its uncertainty when using only SPT-3G data from 1.819 ± 0.038 to 1.812 ± 0.040. Joint constraints from SPT-3G and Planck do not change. The change to the beam covariance has no measureable impact on parameter constraints. These corrections appear in v3.0 of the likelihood as well as the band powers for plotting. 