### PR TITLE
Ensure positivity of various amplitude parameters within the priors (matches cosmomc priors)

### DIFF
--- a/spt3g_2022/EE.yaml
+++ b/spt3g_2022/EE.yaml
@@ -40,3 +40,4 @@ foregrounds:
   tSZ_nu0: 143.0
 
 params: !defaults [param_kappa, params_calib_pol, params_EE]
+priors: !defaults [priors_EE]

--- a/spt3g_2022/EE.yaml
+++ b/spt3g_2022/EE.yaml
@@ -40,4 +40,4 @@ foregrounds:
   tSZ_nu0: 143.0
 
 params: !defaults [param_kappa, params_calib_pol, params_EE]
-priors: !defaults [priors_EE]
+prior: !defaults [priors_EE]

--- a/spt3g_2022/TE.yaml
+++ b/spt3g_2022/TE.yaml
@@ -40,3 +40,4 @@ foregrounds:
   tSZ_nu0: 143.0
 
 params: !defaults [param_kappa, params_calib_temp, params_calib_pol, params_TE]
+priors: !defaults [priors_TE]

--- a/spt3g_2022/TE.yaml
+++ b/spt3g_2022/TE.yaml
@@ -40,4 +40,4 @@ foregrounds:
   tSZ_nu0: 143.0
 
 params: !defaults [param_kappa, params_calib_temp, params_calib_pol, params_TE]
-priors: !defaults [priors_TE]
+prior: !defaults [priors_TE]

--- a/spt3g_2022/TT.yaml
+++ b/spt3g_2022/TT.yaml
@@ -40,4 +40,4 @@ foregrounds:
   tSZ_nu0: 143.0
 
 params: !defaults [param_kappa, params_calib_temp, params_TT]
-priors: !defaults [priors_TT]
+prior: !defaults [priors_TT]

--- a/spt3g_2022/TT.yaml
+++ b/spt3g_2022/TT.yaml
@@ -40,3 +40,4 @@ foregrounds:
   tSZ_nu0: 143.0
 
 params: !defaults [param_kappa, params_calib_temp, params_TT]
+priors: !defaults [priors_TT]

--- a/spt3g_2022/TTTEEE.yaml
+++ b/spt3g_2022/TTTEEE.yaml
@@ -52,4 +52,4 @@ foregrounds:
   tSZ_nu0: 143.0
 
 params: !defaults [param_kappa, params_calib_temp, params_calib_pol, params_TT, params_TE, params_EE]
-priors: !defaults [priors_TT, priors_TE, priors_EE]
+prior: !defaults [priors_TT, priors_TE, priors_EE]

--- a/spt3g_2022/TTTEEE.yaml
+++ b/spt3g_2022/TTTEEE.yaml
@@ -52,3 +52,4 @@ foregrounds:
   tSZ_nu0: 143.0
 
 params: !defaults [param_kappa, params_calib_temp, params_calib_pol, params_TT, params_TE, params_EE]
+priors: !defaults [priors_TT, priors_TE, priors_EE]

--- a/spt3g_2022/params_EE.yaml
+++ b/spt3g_2022/params_EE.yaml
@@ -1,80 +1,71 @@
 EE_Poisson_90x90:
   prior:
-    dist: norm
-    loc: 0.040469
-    scale: 0.012141
+    min: 0.0
+    max: 5.0
   ref: 0.040469
   proposal: 0.01
   latex: D_{3000,95x95}^{\rm{Poisson,EE}}
 
 EE_Poisson_90x150:
   prior:
-    dist: norm
-    loc: 0.018048
-    scale: 0.005414
+    min: 0.0
+    max: 5.0
   ref: 0.018048
   proposal: 0.01
   latex: D_{3000,95x150}^{\rm{Poisson,EE}}
 
 EE_Poisson_90x220:
   prior:
-    dist: norm
-    loc: 0.015719
-    scale: 0.004716
+    min: 0.0
+    max: 5.0
   ref: 0.015719
   proposal: 0.01
   latex: D_{3000,95x220}^{\rm{Poisson,EE}}
 
 EE_Poisson_150x150:
   prior:
-    dist: norm
-    loc: 0.011495
-    scale: 0.003448
+    min: 0.0
+    max: 5.0
   ref: 0.011495
   proposal: 0.01
   latex: D_{3000,150x150}^{\rm{Poisson,EE}}
 
 EE_Poisson_150x220:
   prior:
-    dist: norm
-    loc: 0.018962
-    scale: 0.005689
+    min: 0.0
+    max: 5.0
   ref: 0.018962
   proposal: 0.01
   latex: D_{3000,150x220}^{\rm{Poisson,EE}}
 
 EE_Poisson_220x220:
   prior:
-    dist: norm
-    loc: 0.047557
-    scale: 0.014267
+    min: 0.0
+    max: 5.0
   ref: 0.047557
   proposal: 0.01
   latex: D_{3000,220x220}^{\rm{Poisson,EE}}
 
 EE_PolGalDust_Amp:
   prior:
-    dist: norm
-    loc: 0.05
-    scale: 0.022
+    min: 0.0
+    max: 5.0
   ref: 0.05
   proposal: 0.02
   latex: A_{80}^{\rm{EE}}
 
 EE_PolGalDust_Alpha:
   prior:
-    dist: norm
-    loc: -2.42
-    scale: 0.04
+    min: -5.0
+    max: -1.0
   ref: -2.42
   proposal: 0.04
   latex: \alpha_{\rm{EE}}
 
 EE_PolGalDust_Beta:
   prior:
-    dist: norm
-    loc: 1.51
-    scale: 0.04
+    min: 0.5
+    max: 2.5
   ref: 1.51
   proposal: 0.04
   latex: \beta_{\rm{EE}}

--- a/spt3g_2022/params_TE.yaml
+++ b/spt3g_2022/params_TE.yaml
@@ -1,26 +1,23 @@
 TE_PolGalDust_Amp:
   prior:
-    dist: norm
-    loc: 0.120
-    scale: 0.051
+    min: 0.0
+    max: 5.0
   ref: 0.12
   proposal: 0.051
   latex: A_{80}^{\rm{TE}}
 
 TE_PolGalDust_Alpha:
   prior:
-    dist: norm
-    loc: -2.42
-    scale: 0.04
+    min: -5.0
+    max: -1.0
   ref: -2.42
   proposal: 0.04
   latex: \alpha_{\rm{TE}}
 
 TE_PolGalDust_Beta:
   prior:
-    dist: norm
-    loc: 1.51
-    scale: 0.04
+    min: 0.5
+    max: 2.5
   ref: 1.51
   proposal: 0.04
   latex: \beta_{\rm{TE}}

--- a/spt3g_2022/params_TT.yaml
+++ b/spt3g_2022/params_TT.yaml
@@ -1,91 +1,81 @@
 TT_Poisson_90x90:
   prior:
-    dist: norm
-    loc: 51.3204
-    scale: 9.442
+    min: 0.0
+    max: 200.0
   ref: 52.8146
   proposal: 5.
   latex: D_{3000,95x95}^{\rm{Poisson,TT}}
 
 TT_Poisson_90x150:
   prior:
-    dist: norm
-    loc: 22.4417
-    scale: 7.0881
+    min: 0.0
+    max: 200.0
   ref: 23.9268
   proposal: 5.
   latex: D_{3000,95x150}^{\rm{Poisson,TT}}
 
 TT_Poisson_90x220:
   prior:
-    dist: norm
-    loc: 20.7004
-    scale: 5.9235
+    min: 0.0
+    max: 200.0
   ref: 21.5341
   proposal: 5.
   latex: D_{3000,95x220}^{\rm{Poisson,TT}}
 
 TT_Poisson_150x150:
   prior:
-    dist: norm
-    loc: 15.3455
-    scale: 4.132
+    min: 0.0
+    max: 200.0
   ref: 15.8306
   proposal: 5.
   latex: D_{3000,150x150}^{\rm{Poisson,TT}}
 
 TT_Poisson_150x220:
   prior:
-    dist: norm
-    loc: 28.3573
-    scale: 4.1925
+    min: 0.0
+    max: 200.0
   ref: 26.9362
   proposal: 5.
   latex: D_{3000,150x220}^{\rm{Poisson,TT}}
 
 TT_Poisson_220x220:
   prior:
-    dist: norm
-    loc: 75.9719
-    scale: 14.8624
+    min: 0.0
+    max: 200.0
   ref: 68.2457
   proposal: 5.
   latex: D_{3000,220x220}^{\rm{Poisson,TT}}
 
 TT_GalCirrus_Amp:
   prior:
-    dist: norm
-    loc: 1.88
-    scale: 0.48
+    min: 0.0
+    max: 10.0
   ref: 1.88
   proposal: 0.2
   latex: A^{\rm{cirrus}}_{80}
 
 TT_GalCirrus_Alpha:
   prior:
-    dist: norm
-    loc: -2.53
-    scale: 0.05
+    min: -3.0
+    max: -2.0
   ref: -2.53
   proposal: 0.05
   latex: \alpha^{\rm{cirrus}}
 
 TT_GalCirrus_Beta:
   prior:
-    dist: norm
-    loc: 1.48
-    scale: 0.02
+    min: 0.0
+    max: 2.0
   ref: 1.48
   proposal: 0.1
   latex: \beta^{\rm{cirrus}}
 
 TT_CIBClustering_Amp:
   prior:
-    dist: norm
-    loc: 3.2263
-    scale: 1.8354
+    min: 0.0
+    max: 20.0
   ref: 3.2263
-  proposal: 5.
+  proposal: 1.0
   latex: A^{\rm{CIB-cl}}_{80}
 
 TT_CIBClustering_Alpha:
@@ -94,9 +84,8 @@ TT_CIBClustering_Alpha:
 
 TT_CIBClustering_Beta:
   prior:
-    dist: norm
-    loc: 2.2642
-    scale: 0.3814
+    min: 0.0
+    max: 5.0
   ref: 2.2952
   proposal: 0.5
   latex: \beta^{\rm{CIB-cl}}
@@ -115,27 +104,24 @@ TT_CIBClustering_decorr_220:
 
 TT_tSZ_Amp:
   prior:
-    dist: norm
-    loc: 3.2279
-    scale: 2.3764
+    min: 0.0
+    max: 20.0
   ref: 3.42
   proposal: 0.5
   latex: A^{\rm{tSZ}}
 
 TT_tSZ_CIB_corr:
   prior:
-    dist: norm
-    loc: 0.1801
-    scale: 0.3342
+    min: -1.0
+    max: 1.0
   ref: 0.1144
   proposal: 0.1
   latex: \xi
 
 TT_kSZ_Amp:
   prior:
-    dist: norm
-    loc: 3.7287
-    scale: 4.644
+    min: 0.0
+    max: 20.0
   ref: 3.0
-  proposal: 1.
+  proposal: 1.0
   latex: A^{\rm{kSZ}}

--- a/spt3g_2022/priors_EE.yaml
+++ b/spt3g_2022/priors_EE.yaml
@@ -1,0 +1,18 @@
+gaussian_EE_Poisson_90x90: 'lambda EE_Poisson_90x90: stats.norm.logpdf(EE_Poisson_90x90, loc=0.040469, scale=0.012141)'
+
+gaussian_EE_Poisson_90x150: 'lambda EE_Poisson_90x150: stats.norm.logpdf(EE_Poisson_90x150, loc=0.018048, scale=0.005414)'
+
+gaussian_EE_Poisson_90x220: 'lambda EE_Poisson_90x220: stats.norm.logpdf(EE_Poisson_90x220, loc=0.015719, scale=0.004716)'
+
+gaussian_EE_Poisson_150x150: 'lambda EE_Poisson_150x150: stats.norm.logpdf(EE_Poisson_150x150, loc=0.011495, scale=0.003448)'
+
+gaussian_EE_Poisson_150x220: 'lambda EE_Poisson_150x220: stats.norm.logpdf(EE_Poisson_150x220, loc=0.018962, scale=0.005689)'
+
+gaussian_EE_Poisson_220x220: 'lambda EE_Poisson_220x220: stats.norm.logpdf(EE_Poisson_220x220, loc=0.047557, scale=0.014267)'
+
+gaussian_EE_PolGalDust_Amp: 'lambda EE_PolGalDust_Amp: stats.norm.logpdf(EE_PolGalDust_Amp, loc=0.05, scale=0.022)'
+
+gaussian_EE_PolGalDust_Alpha: 'lambda EE_PolGalDust_Alpha: stats.norm.logpdf(EE_PolGalDust_Alpha, loc=-2.42, scale=0.04)'
+
+gaussian_EE_PolGalDust_Beta: 'lambda EE_PolGalDust_Beta: stats.norm.logpdf(EE_PolGalDust_Beta, loc=1.51, scale=0.04)'
+

--- a/spt3g_2022/priors_TE.yaml
+++ b/spt3g_2022/priors_TE.yaml
@@ -1,0 +1,5 @@
+gaussian_TE_PolGalDust_Amp: 'lambda TE_PolGalDust_Amp: stats.norm.logpdf(TE_PolGalDust_Amp, loc=0.120, scale=0.051)'
+
+gaussian_TE_PolGalDust_Alpha: 'lambda TE_PolGalDust_Alpha: stats.norm.logpdf(TE_PolGalDust_Alpha, loc=-2.42, scale=0.04)'
+
+gaussian_TE_PolGalDust_Beta: 'lambda TE_PolGalDust_Beta: stats.norm.logpdf(TE_PolGalDust_Beta, loc=1.51, scale=0.04)'

--- a/spt3g_2022/priors_TT.yaml
+++ b/spt3g_2022/priors_TT.yaml
@@ -1,0 +1,27 @@
+gaussian_TT_Poisson_90x90: 'lambda TT_Poisson_90x90: stats.norm.logpdf(TT_Poisson_90x90, loc=51.3204, scale=9.442)'
+
+gaussian_TT_Poisson_90x150: 'lambda TT_Poisson_90x150: stats.norm.logpdf(TT_Poisson_90x150, loc=22.4417, scale=7.0881)'
+
+gaussian_TT_Poisson_90x220: 'lambda TT_Poisson_90x220: stats.norm.logpdf(TT_Poisson_90x220, loc=20.7004, scale=5.9235)'
+
+gaussian_TT_Poisson_150x150: 'lambda TT_Poisson_150x150: stats.norm.logpdf(TT_Poisson_150x150, loc=15.3455, scale=4.132)'
+
+gaussian_TT_Poisson_150x220: 'lambda TT_Poisson_150x220: stats.norm.logpdf(TT_Poisson_150x220, loc=28.3573, scale=4.1925)'
+
+gaussian_TT_Poisson_220x220: 'lambda TT_Poisson_220x220: stats.norm.logpdf(TT_Poisson_220x220, loc=75.9719, scale=14.8624)'
+
+gaussian_TT_GalCirrus_Amp: 'lambda TT_GalCirrus_Amp: stats.norm.logpdf(TT_GalCirrus_Amp, loc=1.88, scale=0.48)'
+
+gaussian_TT_GalCirrus_Alpha: 'lambda TT_GalCirrus_Alpha: stats.norm.logpdf(TT_GalCirrus_Alpha, loc=-2.53, scale=0.05)'
+
+gaussian_TT_GalCirrus_Beta: 'lambda TT_GalCirrus_Beta: stats.norm.logpdf(TT_GalCirrus_Beta, loc=1.48, scale=0.02)'
+
+gaussian_TT_CIBClustering_Amp: 'lambda TT_CIBClustering_Amp: stats.norm.logpdf(TT_CIBClustering_Amp, loc=3.2263, scale=1.8354)'
+
+gaussian_TT_CIBClustering_Beta: 'lambda TT_CIBClustering_Beta: stats.norm.logpdf(TT_CIBClustering_Beta, loc=2.2642, scale=0.3814)'
+
+gaussian_TT_tSZ_Amp: 'lambda TT_tSZ_Amp: stats.norm.logpdf(TT_tSZ_Amp, loc=3.2279, scale=2.3764)'
+
+gaussian_TT_tSZ_CIB_corr: 'lambda TT_tSZ_CIB_corr: stats.norm.logpdf(TT_tSZ_CIB_corr, loc=0.1801, scale=0.3342)'
+
+gaussian_TT_kSZ_Amp: 'lambda TT_kSZ_Amp: stats.norm.logpdf(TT_kSZ_Amp, loc=3.7287, scale=4.644)'


### PR DESCRIPTION
The current Python version of the spt3g_2022 likelihood is setting Gaussian distributed prior for various TT, TE and EE amplitude parameters while allowing negative values. This patch truncates the Gaussian to ensure positivity of the amplitudes as to match the priors set in the fortran version of the SPT likelihood (used in cosmomc).

NB: I've fixed and tested only the spt3g_2022 version (older version untouched).

Cheers,
Chris.
